### PR TITLE
Add missing meeting notes

### DIFF
--- a/2024-12-06/README.md
+++ b/2024-12-06/README.md
@@ -1,0 +1,124 @@
+# December SocialCG Meeting 2024-12-06
+Archived: https://www.w3.org/wiki/SocialCG/2024-12-06
+
+https://meet.jit.si/social-web-cg
+
+## Present
+
+* Dmitri Zagidulin
+* Damon
+* nigini (https://nigini.me)
+* Darius Kazemi (@darius@friend.camp)
+* Tantek Çelik (https://tantek.com/)
+* Evan Prodromou <acct:evan@cosocial.ca>
+* [Ted Thibodeau](https://github.com/TallTed/) (he/him) https://mastodon.social/@TallTed
+* Angelo Gladding https://ragt.ag
+* a <trwnh.com>
+* Ryan Barrett (https://snarfed.org/)
+* Emelia Smith (https://hachyderm.io/@thisismissem)
+
+# Agenda
+
+1. IP Protection Note Reminder:
+    - Anyone can participate in these calls. However, all substantive contributors to any CG Work Items must be members of the CG with full IPR agreements signed. https://www.w3.org/community/socialcg/join
+    - To contribute to Work Items: ensure you have a W3 account: https://www.w3.org/accounts/request, and sign the W3C Community Contributor License Agreement (CLA): https://www.w3.org/community/about/agreements/cla/
+2. Introductions & Re-Introductions
+3. Community Announcements
+4. Task Force Updates
+5. Social Web CG Charter PR and issue processing
+    - Aim to get the CG Charter ready to vote on for the January meeting. This means:
+    - Go through [existing PRs](https://github.com/swicg/potential-charters/pulls) and update status
+    - Go through [CG-related issues](https://github.com/swicg/potential-charters/issues?q=is%3Aopen+is%3Aissue+label%3A%22CG+Charter%22)
+6. Social Web CG Staging Process discussion - integrating it with the Charter.
+7. (if time, from previous meeting) C2C protocol TF -- https://lists.w3.org/Archives/Public/public-swicg/2024Nov/0010.html | document protocols built on top of ActivityPub, including how to negotiate protocols client-to-client or actor-to-actor. signalling server behaviors, client behaviors, actor behaviors. generating one or more reports for possible profiles.
+
+# Minutes
+
+
+## Intros
+## Community announcements
+
+* Dec 7 & 8 - IndieWeb San Diego! https://indieweb.org/2024/SD
+* Fosdem (in Brussels) - including an ActivityPub breakout sessions https://fosdem.org/2025/
+* Darius: folks are encouraged to beta test the Fediverse Observatory https://asml.cyber.harvard.edu/fediverseobservatory/ ; send an email to fediverseobservatory@cyber.harvard.edu to request to join
+
+## TaskForce Updates
+
+* Portability/Export TF: meeting in the next hour, right after this call! https://www.w3.org/events/meetings/d5a517d8-2e0b-41ce-8611-956217745157/
+
+* HTML Discovery report — new versions, please review. https://github.com/swicg/activitypub-html-discovery
+    * Evan will coordinate with Tantek on triaging issues, e.g., assigning `rel=me` isssue to Tantek to prioritize
+    * Next meeting this month: (scheduling in progress, Evan to coordinate on meeting time with Dmitri and Tantek)
+
+* Forum/Threaded-Discussions TF — continued discussion on non-Note updates. More to report as the work progresses. Discussed the existing FEPs and how to converge them. So far, the recommendation is to use the `context` field for grouping objects together (not to be confused with `@context`).
+    * Talked about future directions for 2025. Need User Stories for how to "backfill" activities in a discussion thread or collection of objects.
+    * Also would like to explore using the Outbox collection for more stable backfill via Activity log.
+
+* Previous meeting, agreed to start a Group Task Force. Repo over at https://github.com/swicg/groups
+    * Collecting requirements, setting scope
+    * Would like to invite people to contribute User Stories — open issues on Github!
+
+* Geosocial TF — https://github.com/swicg/geosocial working on Explainer, proposed monthly meeting on mailing list.
+
+* Approved a draft Extensions Policy in April this year. Before we take the Policy to final, we want to do some testing.
+    * Historically, extensions were collected within the Miscellany document at https://swicg.github.io/miscellany/
+    * Need more consumers/publishers using this context.
+    * If you have an AP implementation using these popular terms, it's a great time to use this via the link (vs. defining inline in the object)
+    * Sebastian: What about `alsoKnownAs`?
+    * a: That's been added to the `@context`. The documentation is in the DID Core spec.
+    * Emelia: Is there a difference between the published AP spec and the errata?
+    * a: No, it's not defined in the vocab file, just in the AP `@context` and namespace.
+    * Emelia: Should we add it to the Miscellany context?
+    * a: Not sure?
+    * Evan: Let's open an issue on GH to discuss
+
+* Trust and Safety TF — Set up initial scope of work, have multiple workstreams. General focus is on Content Labeling, Formalizing the Flag Activity. Meetings every 2 weeks, next one on Dec 10. (Skipping 24th Dec)
+
+## Social Web CG Charter PR and issue processing
+
+* https://github.com/swicg/potential-charters/pulls
+    * skipping pulls re: effective start dates
+    * [define Committer role](https://github.com/swicg/potential-charters/pull/51)
+        * Evan: It's expected there would be a role of Committer as discussed prior; I added a definition for a Committer as "a person authorized to make changes to Github repos managed by the group"
+        * Dmitri: For clarification, what's the relationship between Committer, or Editor of a report or note, or Task Force leader?
+        * Evan: Good question. We use terms like "Task Force lead" and "editor on the report". These are almost always the same person and are also usually roughly equivalent to someone with commit role on the github repo. 99% of the time these are identical terms for us.
+        * Tantek: Can we not introduce a new term and just re-use the w3c notion of "editor"
+        * plh: I would recommend being careful here. there is [an open issue in the w3c about editors](https://github.com/w3c/process/issues/948). Depending on context, it can mean different things. If you want to avoid that pitfall, "committer" is a good word for the CG.
+        * Dmitri: "Committer" is less formal than editor.
+        * Evan: Also the possibilty of producing software test cases, reference implementations, etc. in which case a committer would be generating software and not touching documents.
+        * a: "Contributor"?
+        * bumblefudge: "Contributor" has an IP implication
+        * a: I don't think the IP thing relates to names; it is about membership in the group, and to be a committer/contributor you probably need to be a member of the group.
+        * plh: This could be a long conversation. Here is an example of a Contributor definition in a previous WG: <https://www.w3.org/Signature/Contributor.html>. It's not related really to your definition.
+        * Dmitri: The tooling/github part is incidental; it's more about contributing to the work of the group.
+        * tantek: plh's examples are good, but they are scoped to Working Groups. That level of formalism makes sense for a WG; not sure we should overindex on formalism for a CG. Let's not add to the number of terms and roles. Lowers the barrier to participation to have less special wording.
+        * a: My second suggestion is "authorized user", because it sounds like it's about commit rights to github repos?
+        * evan: I think there's another issue about uniting these terms. We use champion, task force lead, editor.... Maybe we deal with this async.
+        * Dmitri: We'll follow up on this, async.
+    * https://github.com/swicg/potential-charters/pull/52
+        * Relatively minor PR, reached consensus and merged
+    * https://github.com/swicg/potential-charters/pull/53/
+        * plh: Staging process is about process and group collaboration. You might want to change it frequently, and it's better to keep it separate from the main charter to make this easier to change.
+        * Dmitri: There's strong consensus to not copy the staging process text into the charter. Do we reference it in the charter at all, or do we leave it out?
+        * plh: I am hoping you reference the CLA in the CG charter. I don't want you reinventing the IP process
+        * Emelia: It is important for the staging process to say there is an IPR policy if you want things to move up to the CG or the WG. There's a problem where people do work, and then they think they are going to move forward. Then they realize their employer has a problem with it.
+        * plh: it's fine to provide a reminder in the staging document, I have no problem with that. it's important that when you contribute to the CG you know you are implicitly giving permission to move it to the WG.
+        * Emelia: but the staging process is before the CG
+        * Dmitri: we have a couple decisions for us to make. Does anyone have objections to this specific pull request? The second question is do we mention IP requirements in the group charter?
+        * plh: It would be good for the CG charter to mention IPR
+        * Evan: it's already the case
+        * Dmitri: any objection that we merge the clarification in this pull request to the staging process?
+            * no objection, merged
+    * https://github.com/swicg/potential-charters/pull/54
+        * Dmitri: I understand that WG charters have lists of groups to liaise with. Do we even need that for a CG?
+        * plh: You don't need to mention that in the CG charter. The reason WG charters do that is we want to make clear for the staff when a WG moves forward towards a spec, we actually check to make sure there is communication. But we don't monitor CGs at that level and no one is going to call you on this.
+        * Tantek: I suggest simpler/shorter is better. If you look at the guidance in the comments, this is about significant dependencies. I don't think this CG has significant dependencies on other groups. I don't think updating this list should block the CG charter.
+        * Evan: +1 to tantek
+            * Closed PR
+        * Tantek: added a PR to drop that "significant dependencies" boilerplate: https://github.com/swicg/potential-charters/pull/57
+
+### Issues
+
+* Dmitri: We are running out of time in the meeting. I encourage people to look at these issues between now and the January meeting. The main item of discussion has been around the staging process and whether it should be linked in the charter.
+* Bumblefudge: A lot of these issues are smaller things that can be handled async. The next meeting should focus on staging process.
+* Evan: It would be good to get wider review on the document so we can come into the next meeting with a strong consensus on adopting it. I suggest publishing on the mailing list, SocialSG account, SocialHub, blogs, etc.

--- a/2025-01-03/README.md
+++ b/2025-01-03/README.md
@@ -1,0 +1,128 @@
+# January SocialCG Meeting 2025-01-03
+
+SocialWG on Fedi: https://w3c.social/@socialcg
+
+Archived: https://www.w3.org/wiki/SocialCG/2025-01-03
+
+https://meet.jit.si/social-web-cg
+
+## Present
+
+* Dmitri Zagidulin
+* nigini (https://nigini.me)
+* [Ted Thibodeau](https://github.com/TallTed/) (he/him) https://mastodon.social/@TallTed
+* Andy Piper https://macaw.social/@andypiper
+* Evan Prodromou <acct:evan@cosocial.ca>
+* Emelia Smith <acct:emelia@hachyderm.io>
+* Damon Outlaw 
+* Tantek Çelik [@tantek.com](https://tantek.com/)
+* Angelo Gladding https://ragt.ag
+* Bob Wyman
+
+# Agenda
+
+1. IP Protection Note Reminder:
+    - Anyone can participate in these calls. However, all substantive contributors to any CG Work Items must be members of the CG with full IPR agreements signed. https://www.w3.org/community/socialcg/join
+    - To contribute to Work Items: ensure you have a W3 account: https://www.w3.org/accounts/request, and sign the W3C Community Contributor License Agreement (CLA): https://www.w3.org/community/about/agreements/cla/
+2. Introductions & Re-Introductions
+3. Community Announcements
+4. Task Force Updates
+5. Main Agenda: 2025 Road Map and Wishlist items discussion
+6. (If Time) Social Web CG Charter PR and issue processing
+    - [existing PRs](https://github.com/swicg/potential-charters/pulls) and update status
+    - [CG-related issues](https://github.com/swicg/potential-charters/issues?q=is%3Aopen+is%3Aissue+label%3A%22CG+Charter%22)
+
+# Minutes
+
+## Intros
+
+- Lisa Dusseault: hi everyone, working on Account Portability, etc. (also we have a dev working on a testbed implementation)
+
+    - Emelia: Regarding implementations, highly recommend Hollo (https://github.com/dahlia/hollo ) as a candidate for LOLA implementation (migrate from Mastodon)
+
+    - Emelia: also, hi, I'm involved in IFTAS and other projects, lead of ActivityPub Trust & Safety TF (next meeting Jan 7th), working on initial report for it.
+
+
+## Community announcements
+
+* Darius: folks are encouraged to beta test the Fediverse Observatory https://asml.cyber.harvard.edu/fediverseobservatory/ ; send an email to fediverseobservatory@cyber.harvard.edu to request to join
+
+* Emelia: also, Nivenly will be launching security fund later in the month.
+
+* Evan: Fosdem in February will have a SocialWeb dev room. ~12 talks & implementations. So if you're in Europe and near Brussels, come join. 
+    * Also separate after-hours event (4 more speakers) at Fosdem. 
+* Evan: There will be a Fediverse-related space in SxSW (South by Southwest) conference in Austin.
+
+* Andy: looking forward to Fosdem. Also, published a talk (script, since the video will have  a Japanese dub) of my SocialWeb talk in December. https://andypiper.co.uk/2024/12/24/building-a-better-social-web/
+    * Also, couple of us will be going to RightsCon in Taipei in February
+
+## TaskForce Updates
+
+* Emelia: Discussion on Trust & Safety TF issue needs more eyeballs on it: https://github.com/swicg/activitypub-trust-and-safety/issues/46
+
+* Evan: GeoSocial TF had its first meeting last month, Mike Waggoner and Jeremiah Lee stepped forward to co-lead the TF. 20 or so User Stories around Geosocial activities, covers a lot of ground, lots to review. Next meeting on the 9th next week.
+    * https://github.com/swicg/geosocial
+
+## 2025 Roadmap and Wishlist Item Discussion
+
+* Dmitri: Finish and adopt the CG Charter https://github.com/swicg/potential-charters/
+    * Can we commit to a date?
+    * First, we need to give people sufficient warning, but Q1 and hopefully in the next two months
+    * We need people to check the [issues](https://github.com/swicg/potential-charters/issues) the open PRs
+
+* Emelia: [Pull request #50](https://github.com/swicg/potential-charters/pull/50) can be closed without merge considering the changed dates are passed and we did not reach the deadline
+
+* Evan: wishlist item... standard way for authentication of ActivityPub requests (suggestion, giving some guidance to use OAuth)
+    * Emelia: I'd leave the door open for alternatives. Using discovery to identify what authentication is being used. Example Solid uses multi-authentication. 
+    * Evan: Agree. Giving guidance for OAuth should not block other authentication.
+    * Emelia: Just making sure we don't want to bake OAuth into the protocol
+    * Dmitri: How can we present that? 
+    * Emelia: Use the way that Solid does it now!
+    * Tantek: room for multiple approaches. Document existing approaches. And also express opinions on what some other/better options are, lay down some requirements. Provide an opinionated statement, perhaps advocating for OAuth as Evan suggests, due to its better privacy and security properties for users.
+    * Emelia: perhaps adding an "authentication mechanisms" property to the Actor profile?
+        * Evan: we have that (?)
+        * Emelia: We only have two properties for oauth specifically
+
+* Evan: Wishlist item — FPWD of ActivityPub 1.1, and ActivityStreams 2.1 by the end of the year. (Requires CG charter and a new WG charter set up).
+
+* a: In parallel to signaling Authentication mechanisms for an Actor -- the idea for Profiles for semantics and behaviors. If you see an Actor & Inbox, you have no real ideas of what they produce and accept. Currently, these things are kind of ambiguous. (Like, when you send an Activity, and it's missing an implementation-specific field, it might get rejected etc.) A mechanism for declaring common profiles. For example, "publishing to a microblogging network" profile. A "chess app" profile. etc. Or "Actor supports E2EE messages". 
+    * Emelia: at the moment, a lot of what we see in AP is people looking up Mastodon's implementation and implementing that (compat layer). Would be great to not only signal profiles supported by an actor, but also implementation guides for each.
+
+* Evan: Wishlist item — we have a lot of TaskForces covering a lot of issues. It would be wonderful to see each TF going into 2025 to commit to at least one finalized report!
+
+* Angelo: Was just looking over changes made to the CG charter, and I noticed that the Commit messages were a bit vague (with typos commingled with substantive changes), so it was hard to see diffs. So, wishlist item — clearer diffs/changelogs etc, better commit messages.
+    * +1 Tantek (in chat)
+
+* Dmitri: Wishlist item — chair elections! :)
+
+* Emelia: Wishlist item — w3c's Activity Summary emails tool set up. (weekly automated email) https://github.com/ietf-github-services/activity-summary
+
+* Angelo: related — Unifying with the greater Fediverse. Part of the delay with the charter might be — we don't want to catch the wider community off-guard. So if we had better commit messages, that might address that concern.
+    * +1 Tantek (in chat): to linking in commit messages to when/where decisions were made, so folks could "follow their nose" to better understand reasoning
+
+* Evan: In terms of finishing the charter, what would we need?
+
+* Dmitri: My recommendation — close or label outstanding issues and PRs, announce to the wider community, comment period, then adopt.
+
+* Tantek: My request to the group would be — for any new issues, consider whether it's a charter blocker. And if it's not a blocker, let's mention that in the issue and tag it as such. Or just wait to file the issue.
+    * For the existing CG charter issues (the 10 or so), let's put out a call for PRs to address them.
+
+## Social Web CG Charter PR and issue processing 
+
+### https://github.com/swicg/potential-charters/pull/51
+
+Evan: Discussion of terms used, Committer vs Contributor vs Editor. Champion from the staging doc.
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/2025-02-07/README.md
+++ b/2025-02-07/README.md
@@ -1,0 +1,208 @@
+# February SocialCG Meeting 2025-02-07
+
+Archived: https://www.w3.org/wiki/SocialCG/2025-02-07
+
+https://meet.jit.si/social-web-cg
+
+## Present
+
+* [TallTed // Ted Thibodeau](https://github.com/TallTed/) (he/him) <https://mastodon.social/@TallTed>
+* Dmitri Z.
+* Bob Wyman
+* Darius Kazemi
+* Eric Fassbender
+* [Melvin Carvalho](https://melvincarvalho.com/#me)
+* Angelo Gladding
+* Lisa Dusseault (@lisarue@mastodon.geekery.org)
+* Aaron N Gray
+* [Johannes Ernst](https://j12t.org/)
+* a <trwnh.com>
+* Ryan Barrett <snarfed.org>
+* [elf Pavlik](https://elf-pavlik.hackers4peace.net) (Solid CG)
+* Tantek Çelik (@tantek.com)
+* Jeremiah Lee ([@Jeremiah@alpaca.gold](https://alpaca.gold/@Jeremiah)) (he|they)
+* Emelia Smith (@thisismissem@hachyderm.io)
+* Evan Prodromou <acct:evan@cosocial.ca>
+* Alex Kulikov (@alexeyqu@mastodon.social)
+
+## Agenda
+
+1. IP Protection Note Reminder:
+    - Anyone can participate in these calls. However, all substantive contributors to any CG Work Items must be members of the CG with full IPR agreements signed. https://www.w3.org/community/socialcg/join
+    - To contribute to Work Items: ensure you have a W3 account: https://www.w3.org/accounts/request, and sign the W3C Community Contributor License Agreement (CLA): https://www.w3.org/community/about/agreements/cla/
+2. Introductions & Re-Introductions
+3. Community Announcements
+5. Vote on the [proposed CG charter](https://swicg.github.io/potential-charters/CGCharter-1727386911.html)!
+    * (This kicks off a 14 day Call for Consensus period for comments and objections on the resolution made during the call.)
+6. Task Force Updates
+7. Discussion and issue processing.
+8. FOSDEM report out?
+    * Recording of Jeremiah's demo in Social Web BOF: https://alpaca.gold/@Jeremiah/113956388721652990
+
+## Minutes
+
+### Announcements
+
+Emelia: IFTAS is looking at drastically reducing operations by Mar 30th, unless they raise more money. If anyone knows how to connect them with funding, please help. [link](https://about.iftas.org/2025/02/06/funding-challenges-and-the-future-of-our-work/)
+
+Evan: On March 9-10 at SxSW festival in Austin TX, Flipboard and the SocialWeb Foundation are hosting a Fediverse House!
+Also Bluesky and ATProto work [link](https://about.flipboard.com/fediverse/fediverse-house-2025/)
+
+Elf:  I've been working lately with the team from [ActivityPods](https://activitypods.org/), they've been implementing both ActivityPub and Solid. We start working on a report that might be useful to this group here: https://github.com/solid/activitypub-interop
+
+Johannes Ernst: the 5th  FediForum is coming up, April 1-2nd! More info and registration: https://fediforum.org/ . Same format: unconference and demos. Meet your fellow social web enthusiasts and start new things together!
+
+### Main Agenda
+
+Dmitri: We've been setting up a Community Group charter since the CG has been operating without one. We've discussed this over the past few months, now we think the charter is in pretty good shape to vote on adoption of the [proposed charter](https://swicg.github.io/potential-charters/CGCharter-1727386911.html). Fairly boilerplate, based on a W3C CG charter template. Today we want to vote on a resolution to adopt it, which kicks off a 14-day call for consensus/comments period that is publicized to the mailing list, socialhub, fediverse, and other places where people might want to see it.
+
+Emelia: I see the section "out of scope TBD", do we want to delete it?
+
+Dmitri: there's a [pending PR](https://github.com/swicg/potential-charters/pull/63) around scope. The resolution is to adopt the charter as-is assuming the two issues are resolved. One is the pending PR just mentioned, another is clarification on language around "champion" and "convener".
+
+Emelia: Can we just vote to merge #63 since it's a one line change?
+
+Dmitri: I see plus ones and no objections, let's merge.
+
+Emelia: Can we get a link to the Github repository in the charter itself?
+
+Dmitri: Yes, can you open an issue please.
+
+(PR 63 is merged)
+
+Melvin: In the charter I don't see SocialHub mentioned. Is that intentional?
+
+Dmitri: No it's not left out intentionally. We mention it in the incubation steps (aka staging doc) that we are part of a larger community.
+
+Aaron: I see no mentions of AI. We need a task force, we are going to need to whitelist things re: moderation.
+
+Dmitri: That sounds like a great proposal for a task force, which we have a procedure for. We can add it to the agenda and discuss at the end of the call.
+
+Bob: No need to list everything out in a closed list of discussion topics. Nothing in the charter precludes an AI task force.
+
+Tantek: For the out of scope section, I haven't seen any discussion in this group about blockchain or cryptocurrency based social solutions. Is that something we would simply not mention in the charter, or do we want to explicitly call it out as out of scope?
+
+Bob: I strongly prefer that the particular technology of blockchain not be mentioned in the charter. No reason to elevate that particular set of issues into the charter right now but they can be dealt with as they may come up in the future.
+
+Ryan: I agree with Bob. I'm not personally a big fan but I want us to be able to discuss DSNP or Farcaster if there's anything to be learned from them.
+
+Emelia: We don't need something that says blockchain is specifically out of scope, but we may want to say something about protocols that are non-W3C. Like the intent of the group is for W3C protocol discussion -- if you come in talking about ATProto, sure you can discuss it but you can't expect it to be on topic.
+
+Dmitri: Do the main paragraphs in the scope of work section address what you said?
+
+Emelia: Yes-ish. We also want to say that things that aren't going to be W3C standards or reports or group output aren't going to be in scope.
+
+Dmitri: We do have a very explicit staging process document. Theoretically if someone like ATProto was interested in standardizing they can go through the community process.
+
+Melvin: Replying to Tantek - I am highly sympathetic to his point but I do think that within the blockchain space there are some good bits and the main thing we can benefit from is a global ordering system. They are an instrument to sell tokens and there are de facto royalties which is against W3C policy generally.
+
+Evan: Understanding that Tantek has made a proposal, I wonder if he might consider a rewritten proposal.
+
+Darius: There is a problem where if we add things to the out of scope list, the more we add the more someone might say "because my pet issues isn't in your out of scope list, I have a right to talk about it here".
+
+Emelia: (scribe didn't catch this)
+
+Tantek: I think I got my answer which is that it sounds like there's rough consensus to just not mention blockchain or cryptocurrency explicitly for various reasons. I'm fine to go along with that.
+
+Angelo: I've raised this twice now and haven't gotten much response other than consensus was already reached. You introduced this as the primary substantive changes from the template are scope-related, but there's more in the Chair election process. It's hard to decipher from the commit log. I put together a page on it: https://ragt.ag/socialcg/cg-charter . Specifically what does it mean to be a "discursive" member? Also there are changes to the way Chairs govern this group compared to other groups. (Also mention of the "Solid process" being unclear)
+
+Emelia: What if people who run for chair say what their primary focus is, and then we have find a way to make it so there is a chair from each major community. As far as the discursive language thing, Darius noted it's no longer there. In other contributing documents we do have language that states contributing guidelines for groups.
+
+Dmitri: We do straight-up link to the contribution documents by reference so it's inherent in the charter.
+
+Bumblefudge: In previous conversations this was done intentionally but not formally. There was an informal desire to have the specs under maintenance to be understood really well by one of the chairs. I don't know if it needs to be formalized into the charter to keep happening on a good faith basis, like if we were numerically voting and a bunch of people from one ecosystem came in and got all the top votes. We could simply ask one of them informally to make room for someone from a different ecosystem. But I don't think we need tribe representation among the chairs, it's more of an editor role than an author role. A chair's primary role is to be able to resolve conflicts and understand tradeoffs.
+
+Evan: I want to ask 2 questions of Angelo. Do you feel like you or others cannot approve of this charter with the text as it stands? If that is the case, would a change log with some bullet points that say what the changes from the boilerplate were, would that suffice to overcome your objection?
+
+Angelo: I still don't think I've heard what the "Solid precedent" is? If the changelog was better I would probably understand the "Solid precedent" is.
+
+Dmitri: The "Solid precedent" just means we are taking inspiration from the Solid group for chair election.
+
+Emelia: I was involved in the Solid side. What we were trying to do was to ensure that the ecosystem was well represented and that a single company or organization didn't control the entire specification for Solid.
+
+Evan: If there are specific objections to the document as it stands, I'd like that to be noted. If the changelog is the problem and how we got here is the problem we can address that later by providing a better changelog perhaps.
+
+Dmitri: Angelo, are your concerns about the specifics of the Chair selection process a blocking issue?
+
+Angelo: I could propose a PR to remove things and put it back to the default. But there's a room full of people who seem to think the Solid precedent is the way to go. But there's not good enough documentation to formally justify this. 
+
+Emelia: If you're concerned about this I suggest reaching out to the chairs of the Solid CG and ask them why those decisions were reached.
+
+Melvin: I was first chair of the Solid CG. I personally was not terribly happy with the charter document we landed on. We ended up in a place where the there were three chairs were, or had previously been, employed by the same firm.
+
+Elf: I will respond quickly to the solid CG -- the charter has been mostly edited by Sarven. We approved it a year ago, recently Virginia stepped down. (Sorry, scribe couldn't keep up with this bit of discussion and lacks context)
+
+plh: I want to say that we have been waiting  for this CG to produce a WG charter since 2023. W3C may come up with a proposed WG charter if this doesn't move ahead at the CG level.
+
+Dmitri: calling for a vote on the understanding that this isn't final and changes can happen.
+
+Emelia: are we going for 100% consensus or majority consensus?
+
+Dmitri: rough consensus minus formal objections that can be taken up with w3c staff.
+
+Dmitri: **PROPOSAL:** Adopt the Proposed CG Charter (at 
+https://swicg.github.io/potential-charters/CGCharter-1727386911.html
+ ) as this group's charter, with the understanding that PRs and conversation on it can continue. 
+ 
+ Dmitri: lot of +1s, -1 from Angelo, -0 from Melvin, 0 from Aaron.
+
+Votes: 
+
+- Johannes Ernst: +1 
+- Evan Prodromou: +1 
+- Bob Wyman: +1 
+- bumblefudge: +1 
+- Jeremiah Lee: +1 
+- Ryan Barrett: +1 
+- Aaron N Gray: 0 
+- Dmitri Zagidulin: +1 
+- Angelo Gladding: -1 
+- Melvin Carvalho: -0 
+- Emelia Smith: +1 
+- Tantek Çelik: +1 
+- Ted Thibodeau: +1
+- Aurélien: +1 
+- Darius Kazemi: +1
+- Lisa Dusseault: +1
+- a: +0
+- elf Pavlik: +0 (as not active participant)
+ 
+**Results:** thirteen +1's, two +0, one 0, one -0, one -1, two abstains. Rough consensus and one formal objection (Angelo).
+
+Angelo: Yes, formal objection is to the change to the W3C template regarding chair selection for this charter.
+
+Darius: disagreeing with you is not ignoring you
+
+Evan: Reiterated concern that charter is needed by March
+
+Emelia: given the immediate need for a WG charter, can we convene this meeting weekly or every other week for the time being to make sure it happens?
+
+Dmitri: Good idea, I'll put it to the mailing list.
+
+Dmitri: meeting is being extended by 5-10 minutes. Any last words of advice from plh with regards to this situation in terms of how to procede? Angelo are you raising a formal objection?
+
+Angelo: Yes
+
+plh: It's a CG, so I don't know what you mean when you say there's a formal objection. It is not part of W3C process.
+
+Dmitri: Jitsi recording stops after 1 hour. The meeting is continuing due to importance of topic and minutes will record the conversation.
+
+Dmitri: **PASSED: PROPOSAL:** Adopt the Proposed CG Charter (at 
+https://swicg.github.io/potential-charters/CGCharter-1727386911.html
+ ) as this group's charter, with the understanding that PRs and conversation on it can continue. PENDING async resolution of the objection from Angelo. 
+
+Votes:
+
+- bumblefudge: +1 
+- Tantek Çelik: +1 
+- Aaron N Gray: +1 
+- Evan Prodromou:+1 
+- Emelia Smith: +1 
+- Angelo Gladding: +1 
+- Darius Kazemi: +1 
+- AaronNGray: +1 
+- Bob Wyman: +1
+- Jeremiah Lee: +1 
+- TallTed: +1
+
+**Results:** Full consensus

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ If you would like to upload a recording of a CG meeting in addition to minutes, 
 
 |Date|Topic|
 |---|---|
+|[2025-01-03](2025-01-03/README.md)|General Meeting|
+|[2024-12-06](2024-12-06/README.md)|General Meeting|
 |[2024-11-21](https://lists.w3.org/Archives/Public/public-swicg/2024Nov/0059.html)|Testing TF|
 |[2024-11-20](https://lists.w3.org/Archives/Public/public-swicg/2024Nov/0058.html)|Portability TF|
 |[2024-11-08](2024-11-08/README.md)|General Meeting|

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you would like to upload a recording of a CG meeting in addition to minutes, 
 
 |Date|Topic|
 |---|---|
+|[2025-02-07](2025-02-07/README.md)|General Meeting|
 |[2025-01-03](2025-01-03/README.md)|General Meeting|
 |[2024-12-06](2024-12-06/README.md)|General Meeting|
 |[2024-11-21](https://lists.w3.org/Archives/Public/public-swicg/2024Nov/0059.html)|Testing TF|


### PR DESCRIPTION
This covers:
- 2024-12-06
- 2025-01-03
- 2025-01-07

Meeting notes have also been archived to the W3C Wiki, with the missing wiki-archives for 2024-11 and 2024-10 being converted and added in.