### PR TITLE
feat: backlog of minutes from ActivityPub E2EE Task Force meetings

### DIFF
--- a/2025-12-30-e2ee/README.md
+++ b/2025-12-30-e2ee/README.md
@@ -1,0 +1,30 @@
+---
+title: ActivityPub E2EE SocialCG Task Force 30 Dec 2025
+
+---
+
+# ActivityPub E2EE SocialCG Task Force 30 Dec 2025
+
+## Present
+
+* Evan Prodromou <acct:evanprodromou@socialwebfoundation.org>
+* @mayel@bonfire.cafe
+* Ivan Minutillo <acct:ivan@bonfire.cafe>
+* Ben Pate <acct:@benpate@mastodon.social>
+* Aurélien <acct:@opsocket@mamot.fr>
+
+## Agenda
+
+* Changes to the MLS in ActivityPub spec
+    * Added https://swicg.github.io/activitypub-e2ee/mls#messages
+        * only need to include `mls:messages` on Actor when fetched by the authenticated actor 
+    * use presence of `keyPackages` property on factor to determine if they can receive MLS messages?
+        * https://github.com/swicg/activitypub-e2ee/issues/52
+* Progress (and challenges) on implementations
+    * Bonfire: https://github.com/bonfire-networks/bonfire-app/issues/1701 
+    * 
+* Fossdem?
+* Issue review and triage
+* 
+## Issues
+

--- a/2026-01-27-e2ee/README.md
+++ b/2026-01-27-e2ee/README.md
@@ -1,0 +1,17 @@
+---
+title: ActivityPub E2EE 27 Jan 2026
+
+---
+
+# ActivityPub E2EE 27 Jan 2026
+
+## Present
+
+- Evan Prodromou <acct:evanp@socialwebfoundation.org>
+- ...
+
+## Agenda
+
+- Catch up on issues
+- Status of implementations
+- Needs for FOSDEM

--- a/2026-02-25-e2ee/README.md
+++ b/2026-02-25-e2ee/README.md
@@ -1,0 +1,76 @@
+---
+title: ActivityPub E2EE Task Force Meeting 25 Feb 2026
+
+---
+
+# ActivityPub E2EE Task Force Meeting 25 Feb 2026
+
+## Present
+
+* Evan Prodromou <acct:evanprodromou@socialwebfoundation.org>
+* @mayel@bonfire.cafe
+* Ben Pate
+* @ivan@bonfire.cafe
+* Claire @ mastodon
+* 
+
+## Agenda
+
+1. Introductions/administrative
+2. Progress and implementation reports
+3. https://github.com/swicg/activitypub-e2ee/issues/50 
+4. https://github.com/swicg/activitypub-e2ee/issues/56 
+5. https://github.com/swicg/activitypub-e2ee/issues/46 
+6. https://github.com/swicg/activitypub-e2ee/issues/60 
+7. https://github.com/swicg/activitypub-e2ee/issues/43 
+8. SSE for new messages, related to https://github.com/swicg/activitypub-api/issues/9
+9. internal IDs: mls:// instead of uri:uuid: ?
+10. ap-mls:// as a standard way to open a client at a particular group/thread/message?
+12. Holos...?
+13. https://github.com/swicg/activitypub-e2ee/issues/51
+
+## Notes
+
+### Introductions
+
+- various mutual introductions
+- 
+
+### Progress and implementation reports
+
+- Emissary (Ben Pate)
+    - Posted a video of the process
+    - Create group
+    - Send messages
+    - Key management
+    - SSE
+- Bonfire (Mayel)
+    - Messaging
+    - Key management (remove self, remove others)
+    - Emojis
+    - Verify keys
+    - Remove another device
+
+### Messages by group
+
+- https://github.com/swicg/activitypub-e2ee/issues/50
+
+General consensus that this is not necessary (or a MUST), but using `context` with an `OrderedCollection` a la Threadiverse can be helpful. EP to add a SHOULD requirement to spec.
+
+### Race conditions on GroupInfo
+
+EP to investigate `published`, best practices for groupinfo.
+
+### Actor autocomplete
+
+EP to write up actor autocomplete proposal.
+
+Q: is `endpoints` right way to do this?
+
+## Action Items
+
+- Issue 50: EP to add a SHOULD.
+- Issue 56: check published granularity.
+- Issue 56: suggest using `context`
+- Issue 56: suggestions for best practices for sending groupinfo
+- Issue 46: EP to write up


### PR DESCRIPTION
These are three files from meetings of this task force, for 2025-12, 2026-01, 2026-02. The January one is almost empty; I think we tracked most of the work on GitHub issues.